### PR TITLE
Enhance BingoGenerator: Fix number duplication and improve test coverage

### DIFF
--- a/lib/state/bingo_generator.dart
+++ b/lib/state/bingo_generator.dart
@@ -31,8 +31,22 @@ class BingoGenerator extends _$BingoGenerator {
 
   void _generateNumbers() {
     final random = Random();
-    _numbers = List.generate(_size * _size, (_) => random.nextInt(101));
+    final totalCells = _size * _size;
+
+    // 1から99までの数字を使用（標準的なビンゴの範囲）
+    final availableNumbers = List.generate(99, (index) => index + 1);
+    availableNumbers.shuffle(random);
+
+    // 必要な数だけ取り出す（中央のワイルドカード分を除く）
+    _numbers = availableNumbers.take(totalCells - 1).toList();
+
+    // ワイルドカードを追加
+    _numbers.add(-1);
+
+    // 中央にワイルドカードを配置
     final centerIndex = _numbers.length ~/ 2;
+    final temp = _numbers[centerIndex];
     _numbers[centerIndex] = -1;
+    _numbers[_numbers.length - 1] = temp;
   }
 }

--- a/lib/state/bingo_generator.g.dart
+++ b/lib/state/bingo_generator.g.dart
@@ -6,7 +6,7 @@ part of 'bingo_generator.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$bingoGeneratorHash() => r'b0b0bf7e048ce35914bffd84e381c9efc9cd97b5';
+String _$bingoGeneratorHash() => r'5b64151cd434ce59339023262b8228709b599a9c';
 
 /// See also [BingoGenerator].
 @ProviderFor(BingoGenerator)

--- a/test/bingo_generator_test.dart
+++ b/test/bingo_generator_test.dart
@@ -40,4 +40,37 @@ void main() {
       expect(bingoNumbers[centerIndex], -1);
     });
   });
+
+  test('生成されたカードの番号に重複がないことを確認', () {
+    final container = ProviderContainer();
+    final bingoGenerator = container.read(bingoGeneratorProvider.notifier);
+
+    // サイズを9に設定
+    bingoGenerator.setSize(9);
+
+    // 30回カードを生成してチェック
+    for (int i = 0; i < 30; i++) {
+      bingoGenerator.generateNewCard();
+      final numbers = container.read(bingoGeneratorProvider);
+
+      // 重複チェック
+      final uniqueNumbers = numbers.toSet();
+      expect(uniqueNumbers.length, numbers.length,
+          reason: '重複する番号があります。生成されたカード: $numbers');
+
+      // 範囲チェック
+      expect(
+          numbers.where((n) => n >= 0 && n <= 100).length, numbers.length - 1,
+          reason: '範囲外の番号があります。生成されたカード: $numbers');
+
+      // ワイルドカードチェック
+      expect(numbers.where((n) => n == -1).length, 1,
+          reason: 'ワイルドカードの数が正しくありません。生成されたカード: $numbers');
+
+      // 中央のセルがワイルドカードであることを確認
+      final centerIndex = numbers.length ~/ 2;
+      expect(numbers[centerIndex], -1,
+          reason: '中央のセルがワイルドカードではありません。生成されたカード: $numbers');
+    }
+  });
 }


### PR DESCRIPTION
## 概要
このプルリクエストでは、BingoGeneratorクラスの数字生成ロジックを改善し、重複する数字の問題を解決しました。また、生成されたビンゴカードの品質を確保するための包括的なテストケースを追加しました。

## 変更内容
1. `BingoGenerator` クラスの `_generateNumbers()` メソッドを修正:
   - 数字の範囲を1から99に変更
   - 重複を確実に避けるロジックを実装
   - 中央のワイルドカード配置を保証

2. テストケースの追加:
   - 生成されたカードの番号に重複がないことを確認するテスト
   - カードサイズを9に設定し、30回のカード生成をテスト
   - 各生成に対して以下を検証:
     - 数字の重複がないこと
     - 数字が正しい範囲内にあること
     - ワイルドカードが1つだけ存在すること
     - 中央のセルがワイルドカードであること

## テスト結果
すべての新しいテストケースを含む既存のテストが正常にパスすることを確認しました。

## 影響
この変更によりカード内で重複した番号が存在しない状態となります。


